### PR TITLE
Add radar charts to TOPSIS and Fuzzy TOPSIS pages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "streamlit>=1.29.0",
     "pandas>=2.1.3",
     "numpy>=1.26.0",
+    "plotly>=5.18.0",
 ]
 
 [dependency-groups]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,9 @@ jsonschema-specifications==2025.9.1
 markupsafe==3.0.3
     # via jinja2
 narwhals==2.16.0
-    # via altair
+    # via
+    #   altair
+    #   plotly
 numpy==2.4.2
     # via
     #   mcdm
@@ -53,6 +55,7 @@ numpy==2.4.2
 packaging==26.0
     # via
     #   altair
+    #   plotly
     #   pytest
     #   streamlit
 pandas==2.3.3
@@ -62,6 +65,8 @@ pandas==2.3.3
 pandas-stubs==3.0.0.260204
 pillow==12.1.1
     # via streamlit
+plotly==6.5.2
+    # via mcdm
 pluggy==1.6.0
     # via
     #   pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,9 @@ jsonschema-specifications==2025.9.1
 markupsafe==3.0.3
     # via jinja2
 narwhals==2.16.0
-    # via altair
+    # via
+    #   altair
+    #   plotly
 numpy==2.4.2
     # via
     #   mcdm
@@ -46,6 +48,7 @@ numpy==2.4.2
 packaging==26.0
     # via
     #   altair
+    #   plotly
     #   streamlit
 pandas==2.3.3
     # via
@@ -53,6 +56,8 @@ pandas==2.3.3
     #   streamlit
 pillow==12.1.1
     # via streamlit
+plotly==6.5.2
+    # via mcdm
 protobuf==6.33.5
     # via streamlit
 pyarrow==23.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -375,6 +375,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
+    { name = "plotly" },
     { name = "streamlit" },
 ]
 
@@ -392,6 +393,7 @@ dev = [
 requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pandas", specifier = ">=2.1.3" },
+    { name = "plotly", specifier = ">=5.18.0" },
     { name = "streamlit", specifier = ">=1.29.0" },
 ]
 
@@ -610,6 +612,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
     { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/4f/8a10a9b9f5192cb6fdef62f1d77fa7d834190b2c50c0cd256bd62879212b/plotly-6.5.2.tar.gz", hash = "sha256:7478555be0198562d1435dee4c308268187553cc15516a2f4dd034453699e393", size = 7015695, upload-time = "2026-01-14T21:26:51.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl", hash = "sha256:91757653bd9c550eeea2fa2404dba6b85d1e366d54804c340b2c874e5a7eb4a4", size = 9895973, upload-time = "2026-01-14T21:26:47.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds interactive radar charts to both the TOPSIS and Fuzzy TOPSIS analysis pages to visualize how different options compare across all criteria.

## Key Changes
- **TOPSIS page**: Added radar chart visualization using Plotly that displays normalized weighted scores for each option across all criteria
  - Imported `calculate_normalized_weighted_scores` function to compute the data needed for visualization
  - Created a radar chart that shows all options overlaid for easy comparison
  
- **Fuzzy TOPSIS page**: Added similar radar chart visualization for fuzzy TOPSIS results
  - Imported additional functions: `calculate_normalized_fuzzy_decision_matrix`, `calculate_weighted_normalized_fuzzy_decision_matrix`, and `combine_decision_makers`
  - Extracts the middle value (b) from triangular fuzzy numbers for visualization
  - Displays weighted normalized fuzzy scores in radar format

- **Dependencies**: Added Plotly as a dependency for creating the interactive radar charts

## Implementation Details
- Both implementations follow the same pattern: extract relevant scores from the analysis results, organize them by option and criterion, then create a Plotly radar chart
- The radar charts use a consistent styling with transparent backgrounds and light text color to match the application theme
- Each option is displayed as a separate trace with semi-transparency (opacity=0.6) to allow overlapping visualization
- The charts are fully responsive and use the full container width for better visibility

https://claude.ai/code/session_01MMm5KQa56u5nXe8C2zdUh3